### PR TITLE
Remove catch from reserved words

### DIFF
--- a/reason-lisp/src/lispGrammar.re
+++ b/reason-lisp/src/lispGrammar.re
@@ -875,7 +875,6 @@ let processString = (str) => str |> stripQuotes |> Scanf.unescaped;
   {|"open"|},
   {|"import"|},
   {|"try"|},
-  {|"catch"|},
   {|"from"|}
 ]];
 


### PR DESCRIPTION
`catch` isn't a reserved word in Reason – not sure if it needs to be in Reason-Lisp?