### PR TITLE
Pretty print width

### DIFF
--- a/reason-lisp/src/lisp.re
+++ b/reason-lisp/src/lisp.re
@@ -38,7 +38,7 @@ switch (Sysop.argv) {
   | [|_, "--print", "re", width, "--parse", "re"|] =>
     switch (Str.split(Str.regexp_string("="), width)) {
       | [_, width] =>
-        let width = int_of_string(width);
+        let maxWidth = int_of_string(width);
         let raw = Sysop.readStdin();
         let result = Grammar.getResult(LispGrammar.grammar, "Start", raw);
         /* let result = switch (LispGrammar.start("Start", raw)) {
@@ -46,7 +46,13 @@ switch (Sysop.argv) {
           | exception PackTypes.ConversionError(loc, ruleName, searchedFor) =>
             failwith("Grammar error! Please report this to the lisp.re maintainers. Unable to find " ++ searchedFor ++ " in " ++ ruleName ++ " at " ++ PackTypes.Result.showLoc(loc))
         }; */
-        switch (NewPrettyPrint.startToString(LispGrammar.grammar, result)) {
+        switch (
+          NewPrettyPrint.startToString(
+            ~maxWidth,
+            LispGrammar.grammar,
+            result
+          )
+        ) {
         | Ok(res) => print_string(res)
         | Error(message) =>
           Printf.eprintf("Unable to print %s", message);

--- a/src/NewPrettyPrint.re
+++ b/src/NewPrettyPrint.re
@@ -343,7 +343,7 @@ let toPretty = (grammar: grammar, result) => {
   resultToPretty(false, grammar, result);
 };
 
-let startToString = (~maxWidth=30, grammar, (sub, children, loc, comments)) => {
+let startToString = (~maxWidth=80, grammar, (sub, children, loc, comments)) => {
   let node = Node(("Start", sub), children, loc, comments);
   let%try pretty = resultToPretty(false, grammar, node);
   Ok(prettyString(~width=maxWidth, pretty))


### PR DESCRIPTION
The default of 30 causes unpleasant wrapping in all but the simplest code, so I've increased the default. I've also linked up the cli width argument to the NewPrettyPrint function. Where this would be most useful however is in `reason-language-server`, but I don't know what command that uses to execute `reason-lisp`! Can you help?

Fixes #10